### PR TITLE
Named imports do not destructure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1036,7 +1036,7 @@ export const alpha = 0.35;
 // -------------
 
 // myFile.js
-import { pi, exp } from './mathConstants.js'; // Named import
+import { pi, exp } from './mathConstants.js'; // Named import -- destructuring-like syntax
 console.log(pi) // 3.14
 console.log(exp) // 2.7
 

--- a/readme.md
+++ b/readme.md
@@ -1036,7 +1036,7 @@ export const alpha = 0.35;
 // -------------
 
 // myFile.js
-import { pi, exp } from './mathConstants.js'; // Destructuring import
+import { pi, exp } from './mathConstants.js'; // Named import
 console.log(pi) // 3.14
 console.log(exp) // 2.7
 


### PR DESCRIPTION
Despite looking very similar, named imports do not destructure. 

So you can't do this in ES6:

`import { foo: { bar } } from 'my-module';`