### PR TITLE
Update page title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 theme: jekyll-theme-cayman
-title: modern-js-cheatsheet
+title: ''

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-cayman
+title: modern-js-cheatsheet


### PR DESCRIPTION
Fixes #32 

The page will now use the title *modern-js-cheatsheet*.