### PR TITLE
Put falsy values into backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1418,12 +1418,12 @@ In JavaScript, a truthy or falsy value is a value that is being casted into a bo
 
 Every value will be casted to ```true``` unless they are equal to:
 
-- false
-- 0
-- "" (empty string)
-- null
-- undefined
-- NaN
+- ```false```
+- ```0```
+- ```""``` (empty string)
+- ```null```
+- ```undefined```
+- ```NaN```
 
 Here are examples of *boolean context*:
 


### PR DESCRIPTION
This change prevents Jekyll from replacing quotes characters by typographical quotes. It makes the content clearer too.