### PR TITLE
Fix generator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1616,7 +1616,7 @@ function * downToOne(n) {
   }
 }
 
-[...downToOne(5)] //[ 1, 2, 3, 4, 5 ]
+[...downToOne(5)] //[ 5, 4, 3, 2, 1 ]
 ```
 
 Generators return an iterable object. When the iterator's `next()` function is called, it is executed until the first `yield` expression, which specifies the value to be returned from the iterator or with `yield*`, which delegates to another generator function. When a `return` expression is called in the generator, it will mark the generator as done and pass back as the return value. Further calls to `next()` will not return any new values.


### PR DESCRIPTION
The `downToOne` example returned the list in a reversed order

See screenshot for proof

<img width="272" alt="screen shot 2017-11-04 at 10 49 17" src="https://user-images.githubusercontent.com/407891/32404329-eddc90d4-c14d-11e7-8898-e3444c72fd39.png">
