### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,7 +1265,7 @@ class Person {
   }
 
   stringSentence() {
-    return "Hello, my name is " + this.name + " and I'm " + this.age;
+    return `Hello, my name is ${this.name} and I am ${this.age}`;
   }
 }
 


### PR DESCRIPTION
Why if you give an ES6 example just not to use literal templates, which are from ES6 too?